### PR TITLE
Fix table headers of "My Courses" table

### DIFF
--- a/crates/tucant-yew/src/my_courses.rs
+++ b/crates/tucant-yew/src/my_courses.rs
@@ -36,10 +36,10 @@ pub fn my_courses<TucanType: Tucan + 'static>() -> Html {
                                         {"Name"}
                                     </th>
                                     <th scope="col">
-                                        {"Verantwortliche Person"}
+                                        {"Zeitraum"}
                                     </th>
                                     <th scope="col">
-                                        {"Credits"}
+                                        {"Standort"}
                                     </th>
                                 </tr>
                             </thead>


### PR DESCRIPTION
Header labels were off:
- Replaced "Verantwortliche Person" with "Zeitraum"
- Replaced "Credits" with "Standort"